### PR TITLE
Configuração de modo escuro automático

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
-remote_theme: "pmarsceill/just-the-docs"
+remote_theme: "ThundeRatz/just-the-docs"
 
-color_scheme: dark
+color_scheme: autodark
 
 logo: https://static.thunderatz.org/teamassets/logo-simples-sf-amarelo.png
 


### PR DESCRIPTION
Salve salve pessoal

Fiz alguns ajustes para que o modo escuro do site fosse habilitável de acordo com as configurações do usuário

A [documentação oficial](https://pmarsceill.github.io/just-the-docs/docs/customization/#color-schemes) do Just-the-docs mostra o exemplo de como fazer isso com javascript, porém o problema é que a tema fica piscando toda vez que mudamos de página. Para corrigir isso, segui [esse tutorial](https://derekkedziora.com/blog/dark-mode-revisited) para fazer as configurações de modo escuro automático diretamente no CSS da página.

Foram necessárias algumas modificações no CSS do template, por isso fiz um [fork do Just-the-docs](https://github.com/ThundeRatz/just-the-docs) na organização ThundeRatz, pretendo logo mais abrir uma PR pra propagar essas mudanças no projeto original.

Com isso, agora o site herda as configurações do navegador pra habilitar ou não o modo escuro. No caso do Firefox, o navegador utiliza as mesmas configurações do sistema operacional.

Demonstrando o funcionamento, aqui está um gif top. É possível conferir o funcionamento da troca claro/escuro no [fork que eu fiz do projeto](https://felipegdm.github.io/Pages_sandbox/)

![ezgif com-gif-maker](https://user-images.githubusercontent.com/1054087/113199889-07b71a00-923e-11eb-9ea1-8d85cc87294d.gif)

No mais, era isso que tinha pra mostrar pra vcs, fiquem bem e mantenham-se hidratados